### PR TITLE
Add implementation notes for Ironic API calls as stubs/TODOs

### DIFF
--- a/api/designs/002-ironic-client-setup.md
+++ b/api/designs/002-ironic-client-setup.md
@@ -27,6 +27,10 @@ The Ironic client wrapper follows the stateless architecture:
 4. Add Ironic connectivity to health checks
 5. Provide async-compatible interface
 
+## Implementation Note
+
+**Ironic API calls should be left as stubs/TODOs.** The implementer should create the client class structure, method signatures, and error handling framework, but leave the actual Ironic SDK calls as TODO comments for manual implementation. This allows the project owner to write the specific Ironic interaction logic themselves.
+
 ## Dependencies
 
 | Package | Version | Purpose |

--- a/api/designs/003-server-enroll-workflow.md
+++ b/api/designs/003-server-enroll-workflow.md
@@ -27,6 +27,10 @@ The enrollment workflow is stateless:
 4. Provide sensible defaults while allowing customization
 5. Return enrolled server details
 
+## Implementation Note
+
+**Ironic API calls should be left as stubs/TODOs.** Implement the full service structure, schemas, routers, and MCP tools, but leave the actual Ironic client method calls (e.g., creating nodes, validating BMC connectivity) as TODO comments for manual implementation.
+
 ## Business Requirements
 
 Internal customers need to:

--- a/api/designs/004-server-list-process.md
+++ b/api/designs/004-server-list-process.md
@@ -26,6 +26,10 @@ The server listing workflow is stateless:
 3. Expose via REST endpoint and MCP tool
 4. Support pagination for large inventories
 
+## Implementation Note
+
+**Ironic API calls should be left as stubs/TODOs.** Implement the full service structure, schemas, routers, and MCP tools, but leave the actual Ironic client method calls (e.g., listing nodes, getting node details) as TODO comments for manual implementation.
+
 ## Business Requirements
 
 Internal customers need to:

--- a/api/designs/005-server-provision-workflow.md
+++ b/api/designs/005-server-provision-workflow.md
@@ -28,6 +28,10 @@ The provisioning workflow is stateless:
 4. Provide operation status tracking
 5. Handle provisioning failures gracefully
 
+## Implementation Note
+
+**Ironic API calls should be left as stubs/TODOs.** Implement the full service structure, schemas, routers, and MCP tools, but leave the actual Ironic client method calls (e.g., setting deploy parameters, triggering provisioning, querying provision state) as TODO comments for manual implementation.
+
 ## Business Requirements
 
 Internal customers need to:

--- a/api/designs/006-server-unprovision-workflow.md
+++ b/api/designs/006-server-unprovision-workflow.md
@@ -31,6 +31,10 @@ Operation tracking follows the same pattern as provisioning:
 3. Support optional data wiping/cleaning configuration
 4. Provide operation status tracking
 
+## Implementation Note
+
+**Ironic API calls should be left as stubs/TODOs.** Implement the full service structure, schemas, routers, and MCP tools, but leave the actual Ironic client method calls (e.g., triggering cleaning, querying unprovision state) as TODO comments for manual implementation.
+
 ## Business Requirements
 
 Internal customers need to:

--- a/api/designs/008-authorization.md
+++ b/api/designs/008-authorization.md
@@ -26,6 +26,10 @@ Authorization remains stateless:
 3. Define clear permission model for API operations
 4. Maintain backward compatibility when auth is disabled
 
+## Implementation Note
+
+**Ironic API calls should be left as stubs/TODOs.** Implement the full authorization framework, but leave the actual Ironic client method calls (e.g., fetching node ownership/lessee fields) as TODO comments for manual implementation.
+
 ## Business Requirements
 
 - Admins can manage all servers


### PR DESCRIPTION
Include implementation notes across design documents indicating that Ironic API calls should be left as stubs/TODOs for manual implementation. This allows for flexibility in writing specific Ironic interaction logic.