### PR TITLE
Add AIO API service and configure NGINX reverse proxy with authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,18 @@ services:
       - ${IRONIC_VMEDIA_DIR:-/opt/ironic/vmedia}:/app/vmedia
     restart: unless-stopped
 
+  api:
+    image: ghcr.io/mattcburns/ironic-aio-api:v0.0.1
+    expose:
+      - 8000:8000
+    environment:
+      - IRONIC_AIO_IRONIC_API_URL=http://ironic:6385
+      - IRONIC_AIO_IRONIC_API_VERSION=1.82
+
   nginx:
     image: nginx:alpine
     ports:
+      - 443:443     # AIO API (HTTPS)
       - 6385:6385  # Ironic API (HTTPS)
       - 8080:8080   # VMedia server
     volumes:

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,50 @@ http {
     tcp_nopush on;
     keepalive_timeout 65;
 
+    # AIO API reverse proxy (HTTPS - default port 443)
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate     /etc/nginx/ssl/tls.crt;
+        ssl_certificate_key /etc/nginx/ssl/tls.key;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+
+        location / {
+            # --- ALLOWLIST CONFIGURATION ---
+            # Add or change allowed IPs/subnets below to bypass authentication.
+            # Example: allow 172.16.0.0/12; # Docker default bridge network range
+            # allow 192.168.1.0/24; # Example: custom subnet
+            # To require auth for all, comment out all 'allow' lines except 'deny all;'
+            satisfy any;
+            allow 172.16.0.0/12; # Docker default bridge network range
+            # allow 192.168.1.0/24; # Example: custom subnet
+            deny all;
+            # --- END ALLOWLIST CONFIGURATION ---
+
+            auth_basic "Ironic API";
+
+            # NOTE: The htpasswd file below MUST be present and properly mounted.
+            # If this file is missing, all requests from non-allowlisted IPs will be denied,
+            # even if valid credentials are provided. This is due to the use of 'satisfy any;'
+            # with an allowlist and authentication fallback. Ensure this file is not optional
+            # when authentication is required for non-allowlisted IPs.
+            auth_basic_user_file /etc/nginx/htpasswd;
+
+            proxy_pass http://api:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Increase timeouts for long-running operations
+            proxy_connect_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+        }
+    }
+
     # Ironic API reverse proxy (HTTPS)
     server {
         listen 6385 ssl;


### PR DESCRIPTION
Introduce an AIO API service and set up an NGINX reverse proxy with authentication, allowing access control through an allowlist and basic authentication for enhanced security.